### PR TITLE
[fix] 프로필 상세조회 areWeFriend null 오류 해결

### DIFF
--- a/src/main/java/kr/org/dagather/domain/friend/repository/FriendRepository.java
+++ b/src/main/java/kr/org/dagather/domain/friend/repository/FriendRepository.java
@@ -19,5 +19,5 @@ public interface FriendRepository extends JpaRepository<Friend, Long> {
 	List<Friend> findFriendsByMemberId(@Param("memberId") String memberId);
 	boolean existsByChatroomId(String chatroomId);
 	@Query("select f.areWeFriend from Friend f where (f.sender = :me and f.receiver = :you) or (f.sender = :you and f.receiver = :me)")
-	boolean areWeFriend(@Param("me") String me, @Param("you") String you);
+	Optional<Boolean> areWeFriend(@Param("me") String me, @Param("you") String you);
 }

--- a/src/main/java/kr/org/dagather/domain/profile/service/ProfileService.java
+++ b/src/main/java/kr/org/dagather/domain/profile/service/ProfileService.java
@@ -117,7 +117,7 @@ public class ProfileService {
 		profileInterests.forEach(i -> { interests.add(new ProfileInterestDto(i.getInterest(), myInterests.contains(i.getInterest()))); });
 
 		// add are we friend
-		boolean areWeFriend = friendRepository.areWeFriend(currentMemberId, memberId);
+		boolean areWeFriend = friendRepository.areWeFriend(currentMemberId, memberId).orElse(false);
 
 		return profileMapper.toGetResponseDto(profile, purposes, interests, areWeFriend);
 	}


### PR DESCRIPTION
## ✅ 체크리스트
- [ ] 테스트 코드가 잘 통과되나요?
- [ ] 이 프로젝트의 코드 스타일을 따르나요?
- [ ] 문서변경이 필요한 경우, 변경하였나요?

## 📋 변경 유형
- [x] Bug
- [ ] Feature
- [ ] Breaking change (기존 기능을 변경하게 하는 bug 또는 feature)

## ✏️ PR 개요
- 프로필 상세조회 시 Friend DB에 아예 생성되지 않은 데이터 컬럼의 areWeFriend를 가져오려고 하는 경우 null 오류 해결

resolved: #이슈번호
